### PR TITLE
Fix EventResource return error when passing a null

### DIFF
--- a/app/Http/Resources/Event.php
+++ b/app/Http/Resources/Event.php
@@ -17,6 +17,10 @@ class Event extends JsonResource
      */
     public function toArray($request)
     {
+        if (is_null($this->resource)) {
+            return [];
+        }
+
         return [
             'id'           => $this->id,
             'name'         => $this->name,


### PR DESCRIPTION
**Changes**:
Return empty array when the given resource is null. I decide to return empty array so the developer can modify their display freely.

Solve issue #107 